### PR TITLE
Add load_nidq(path) in save_nidq

### DIFF
--- a/ephys/bmi.py
+++ b/ephys/bmi.py
@@ -435,6 +435,9 @@ class BMI:
     def save_nidq(self, path=None):
         if path is None:
             path = self.path
+
+        if not hasattr(self, 'nidq_fn') or not self.nidq_fn:
+            self.load_nidq(path)
         
         for i, fn in enumerate(self.nidq_fn):
             if not hasattr(self, 'nidq'):

--- a/ephys/ks.py
+++ b/ephys/ks.py
@@ -78,7 +78,7 @@ class Spike():
 
     def load_meta(self):
         ops = np.load(os.path.join(self.path, 'ops.npy'), allow_pickle=True).item()
-        self.data_file_path_orig = str(ops['data_file_path'])
+        self.data_file_path_orig = os.path.join(str(ops['data_dir']),str(ops['filename']))
         parent_folder = os.path.dirname(self.path)
         self.data_file_path = finder(parent_folder, 'ap.bin$', ask=False)[0]
 
@@ -105,10 +105,10 @@ class Spike():
         spike_templates = np.load(os.path.join(self.path, 'spike_templates.npy'))
         
         # Load cluster information
-        cluster_info = pd.read_csv(os.path.join(self.path, 'cluster_info.tsv'), sep='\t')
+        cluster_group = pd.read_csv(os.path.join(self.path, 'cluster_group.tsv'), sep='\t')
         
         # Get IDs of good clusters
-        good_id = cluster_info[cluster_info['group'] == 'good'].cluster_id.values
+        good_id = cluster_group[cluster_group['KSLabel'] == 'good'].cluster_id.values
         
         # Find the main template ID for each good cluster
         main_template_id = [np.bincount(spike_templates[cluster == c]).argmax() 


### PR DESCRIPTION
### bmi.py
Problem:
When executing the **_savebmi_** command, an _AttributeError: 'BMI' object has no attribute 'nidq_fn'_ occurs. This error likely originates from the _**bmi.save_nidq()**_ function, where nidq_fn is accessed before it has been properly initialized.

Solution:
**I resolved the error by ensuring that the nidq_fn attribute is correctly initialized** before it is used in the save_nidq() method. The code now checks whether nidq_fn is initialized, and if not, it calls load_nidq() to properly set up the nidq_fn attribute before proceeding with the save operation

### ks.py
I encountered issues related to **incorrect file paths and filenames** in _ks.py._ So I resolved it by **correcting the file path and file name.** I also refactored the code structure to ensure compatibility with the updated file paths.